### PR TITLE
remove unnecessary react import

### DIFF
--- a/template/src/App.js
+++ b/template/src/App.js
@@ -1,5 +1,3 @@
-import React from 'react';
-
 function App() {
   return (
     <div className="App">


### PR DESCRIPTION
From React 17 onwards, react is no longer required to process JSX. So, we can remove react import in App.js