### PR TITLE
Update deprecated DOM render in React 18

### DIFF
--- a/template/src/index.js
+++ b/template/src/index.js
@@ -1,11 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-ReactDOM.render(
+const root = createRoot(document.getElementById('root'))
+
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );

--- a/template/src/index.js
+++ b/template/src/index.js
@@ -3,7 +3,7 @@ import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App';
 
-const root = createRoot(document.getElementById('root'))
+const root = createRoot(document.getElementById('root'));
 
 root.render(
   <React.StrictMode>


### PR DESCRIPTION
Update ReactDOM.render to createRoot().render. Resolve issue #2 